### PR TITLE
fix(ci): trigger test workflow on pull_request_target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@
 name: Tests
 
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches:
       - main
 


### PR DESCRIPTION
This allows PRs raised by dependabot to use the test workflow which requires access to the github app for gaining readonly access to private go module repos.