### PR TITLE
fix(ci): Allow dependabot PRs to generate temporary github app tokens.

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,0 +1,12 @@
+---
+name: Dependabot PR check
+
+on: pull_request
+
+jobs:
+  dependabot-check:
+    name: Check for dependabot
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - run: echo "PR created by Dependabot"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches:
       - main
+  workflow_run:
+    workflows:
+      - "Dependabot PR Check"
+    types:
+      - completed
 
 jobs:
   goreleaser:


### PR DESCRIPTION
This allows PRs raised by dependabot to use the test workflow which requires access to the github app for gaining readonly access to private go module repos.